### PR TITLE
Replaced OpenCL installation with a nvidia proper base image

### DIFF
--- a/containers/Dockerfile.intel
+++ b/containers/Dockerfile.intel
@@ -1,18 +1,9 @@
-FROM ubuntu:16.04
+FROM nvidia/opencl
 
 RUN mkdir -p /src
-COPY containers/silent.cfg /src
 
 # install dependencies 
 RUN apt-get update && apt-get install -y lsb-core wget
-
-# install Intel OpenCL runtime
-RUN cd /src && \ 
-    wget http://registrationcenter-download.intel.com/akdlm/irc_nas/9019/opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz && \
-	tar -xvzf opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25.tgz && \
-	mv silent.cfg opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25 && \
-	cd opencl_runtime_16.1.1_x64_ubuntu_6.4.0.25 && \
-	./install.sh --silent silent.cfg --cli-mode
 
 # install mdt
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
Referring to issue #19 we replaced the download and installation of OpenCL with a standard nvidia/opencl base image.

The output of the command:

`$ docker run --gpus all <mdt-image> mdt-list-devices`

is now:

```
Device 0:
GPU - TITAN RTX (NVIDIA CUDA)
Device 1:
CPU - pthread-Intel(R) Xeon(R) Silver 4114 CPU @ 2.20GHz (Portable Computing Language)
```
