### PR TITLE
Update physical_diffusion_models.py

### DIFF
--- a/mdt/data/components/standard/library_functions/physical_diffusion_models.py
+++ b/mdt/data/components/standard/library_functions/physical_diffusion_models.py
@@ -172,7 +172,7 @@ class VanGelderenSphere(LibraryFunctionTemplate):
     """
     return_type = 'double'
     parameters = ['double G', 'double Delta', 'double delta', 'double d', 'double R']
-    dependencies = ['MRIConstants']
+    dependencies = ['MRIConstants', 'BesselRoots']
     cl_code = '''
         if(R == 0.0 || R < MOT_EPSILON){
             return 0;


### PR DESCRIPTION
Fixed dependency error on Bessel functions when using GDP/VanGelderenSphere.